### PR TITLE
use parentheses to remove ambiguity in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,8 +7,8 @@ defmodule CalendarTranslations.Mixfile do
     [app: :calendar_translations,
      version: @version,
      elixir: "~> 1.1",
-     package: package,
-     description: description,
+     package: package(),
+     description: description(),
      deps: deps(),
 
      # Docs

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule CalendarTranslations.Mixfile do
      elixir: "~> 1.1",
      package: package,
      description: description,
-     deps: deps,
+     deps: deps(),
 
      # Docs
      name: "CalendarTranslations",


### PR DESCRIPTION
got this error

```
warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name

warning: variable "description" does not exist and is being expanded to "description()", please use parentheses to remove the ambiguity or change the variable name
  /my_app/deps/calendar_translations/mix.exs:11

warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  /my_app/deps/calendar_translations/mix.exs:12
```
